### PR TITLE
better-ish API - no need to write 'from ish import ish'

### DIFF
--- a/ish/ish.py
+++ b/ish/ish.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 
 TRUE_STRINGS = [
     'true', 'yes', 'on', '1', 'yeah', 'yup',
@@ -55,6 +57,25 @@ class Ish(object):
 trueish = TrueIsh()
 falseish = FalseIsh()
 ish = Ish()
+__rsub__ = ish.__rsub__
+
+
+class RsubableModule(type(sys)):
+    def __init__(self, original_module):
+        type(sys).__init__(self, original_module.__name__)
+        self._original_module = original_module
+
+    def __rsub__(self, *args, **kwargs):
+        return self._original_module.__rsub__(*args, **kwargs)
+
+    def __getattribute__(self, item):
+        if item in ['__rsub__', '_original_module']:
+            return object.__getattribute__(self, item)
+        return getattr(self._original_module, item)
+
+
+sys.modules[__name__] = RsubableModule(sys.modules[__name__])
+
 
 if __name__ == '__main__':
     print 'Yup' == True-ish

--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -2,13 +2,16 @@
 
 import pytest
 
-from ish import ish
+import ish
+from ish import ish as ish_  # backwards compatibility
 from ish import TRUE_STRINGS
 
 
 def test_true_ish():
     assert 'Yeah' == True-ish
     assert 'yup' == True-ish
+    assert 'Yeah' == True-ish_
+    assert 'yup' == True-ish_
 
 
 def test_true_ish_unicode():


### PR DESCRIPTION
Hi,

Me and @eliasdorneles realized that ish API could be better. We're using it heavily in production, and `from ish import ish` is too verbose and tiresome to type. We wanted to be able to do just `import ish`, which provides a cleaner and DRYer API. The implementation is in this PR. 

What do you think about it? There are tests and changes are fully backwards compatible.
