### PR TITLE
Refactored/Simplified ish module

### DIFF
--- a/ish/ish.py
+++ b/ish/ish.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import sys
+import string
 
 try:
     from deep_neural_network.face_classifier import detect_and_predict_face_emotion
@@ -31,6 +32,7 @@ FALSE_STRINGS = {
     'nee',   # Dutch
     u'ﻷ',    # Arabic
 }
+STRIP_CHARS = string.whitespace + string.punctuation
 
 HAPPY_STRINGS = {
     'happy',
@@ -59,7 +61,7 @@ class Maybe(ValueError):
 def normalize_string(s):
     if isinstance(s, bytes):
         s = s.decode('utf-8', 'replace')
-    return s.strip().lower()
+    return s.strip(STRIP_CHARS).lower()
 
 
 class BaseIsh(object):

--- a/ish/ish.py
+++ b/ish/ish.py
@@ -89,10 +89,11 @@ class BoolIsh(BaseIsh):
         raise Maybe(s)
 
     def __eq__(self, other):
-        if isinstance(other, basestring):
+        result = bool(other)
+
+        if result and isinstance(other, basestring):
             result = self._check_string(other)
-        else:
-            result = bool(other)
+
         return result == self._value
 
 trueish = BoolIsh(True)

--- a/ish/ish.py
+++ b/ish/ish.py
@@ -5,156 +5,142 @@ import sys
 
 try:
     from deep_neural_network.face_classifier import detect_and_predict_face_emotion
-except:
-    detect_and_predict_face = None
-
-
-def _is_image(img):
-    try:
-        shape = img.shape
-        if len(shape) == 3 and shape[2] == 3:
-            return True
-        elif len(shape) == 2:
-            return True
-    except:
-        pass
-
-    return False
-
-
-class UnIshable(Exception):
-    pass
-
-
-TRUE_STRINGS = [
-    'true', 'yes', 'on', '1', 'yeah', 'yup', 'yarp',
-    'oui',  # French
-    'ja',   # German, Danish, Dutch, Afrikaans, Swedish, Norwegian
-    'sim',  # Portuguese
-    'sea',  # Irish
-    'jes',  # Esperanto
-    u'نعم'.lower(),  # Arabic
-]
-FALSE_STRINGS = [
-    'false', 'no', 'off' '0', 'nope', 'nah', 'narp',
-    'non',   # French
-    'nein',  # German
-    'nej',   # Danish
-    'nee',   # Dutch
-    u'لأ'.lower(),     # Arabic
-]
-HAPPY_STRINGS = [
-    'happy',
-    'happy-face',
-    'joyful',
-]
-ANGRY_STRINGS = [
-    'angry',
-    'anger',
-    'grrr',
-]
-NEUTRAL_STRINGS = [
-    'neutral',
-]
+except ImportError:
+    detect_and_predict_face_emotion = None
 
 try:
     basestring
 except NameError:
     basestring = (str, bytes)
 
+
+TRUE_STRINGS = {
+    'true', 'yes', 'on', '1', 'yeah', 'yup', 'yarp',
+    'oui',  # French
+    'ja',   # German, Danish, Dutch, Afrikaans, Swedish, Norwegian
+    'sim',  # Portuguese
+    'sea',  # Irish
+    'jes',  # Esperanto
+    u'ﻦﻌﻣ', # Arabic
+}
+FALSE_STRINGS = {
+    'false', 'no', 'off', '0', 'nope', 'nah', 'narp',
+    'non',   # French
+    'nein',  # German
+    'nej',   # Danish
+    'nee',   # Dutch
+    u'ﻷ',    # Arabic
+}
+
+HAPPY_STRINGS = {
+    'happy',
+    'happy-face',
+    'joyful',
+}
+ANGRY_STRINGS = {
+    'angry',
+    'anger',
+    'grrr',
+}
+NEUTRAL_STRINGS = {
+    'neutral',
+}
+
+
+class UnIshable(Exception):
+    def __init__(self, value):
+        super(UnIshable, self).__init__('{!r} can not be ished!'.format(value))
+
+class Maybe(ValueError):
+    def __init__(self, value):
+        super(Maybe, self).__init__('Maybe! ({!r} is not recognised)'.format(value))
+
+
 def normalize_string(s):
     if isinstance(s, bytes):
         s = s.decode('utf-8', 'replace')
     return s.strip().lower()
 
-class TrueIsh(object):
+
+class BaseIsh(object):
+    def __init__(self, value):
+        self._value = value
+
+    def __repr__(self):
+        return '{!r}-{!r}'.format(self._value, ish)
+
+
+class BoolIsh(BaseIsh):
+    def _check_string(self, s):
+        normalized = normalize_string(s)
+
+        if normalized in TRUE_STRINGS:
+            return True
+        if normalized in FALSE_STRINGS:
+            return False
+
+        raise Maybe(s)
+
     def __eq__(self, other):
         if isinstance(other, basestring):
-            cleaned_value = normalize_string(other)
-            is_trueish = cleaned_value in TRUE_STRINGS
-            is_falseish = cleaned_value in FALSE_STRINGS
-            # print is_trueish, is_falseish
-            if is_trueish:
-                return True
-            elif is_falseish:
-                return False
-            else:
-                raise ValueError(
-                    "Maybe! ({!r} is not recognised)".format(other))
+            result = self._check_string(other)
         else:
-            return bool(other)
+            result = bool(other)
+        return result == self._value
+
+trueish = BoolIsh(True)
+falseish = BoolIsh(False)
 
 
-class FalseIsh(object):
+class EmotionIsh(BaseIsh):
+    def __init__(self, value):
+        if detect_and_predict_face_emotion:
+            super(EmotionIsh, self).__init__(value)
+            normalized = normalize_string(value)
+            for (type, keywords) in ((3, HAPPY_STRINGS),
+                                     (0, ANGRY_STRINGS),
+                                     (6, NEUTRAL_STRINGS)):
+                if normalized in keywords:
+                    self._type = type
+                    return
+
+        raise UnIshable(value)
+
+    def _is_image(self, img):
+        try:
+            shape = img.shape
+            if len(shape) == 3 and shape[2] == 3:
+                return True
+            if len(shape) == 2:
+                return True
+        except Exception:
+            return False
+
     def __eq__(self, other):
-        return not trueish.__eq__(other)
-
-
-class HappyIsh(object):
-    def __eq__(self, other):
-        if detect_and_predict_face_emotion is not None and _is_image(other):
-            return detect_and_predict_face_emotion(other) == 3
-        raise ValueError(
-            "Maybe! ({!r} is not recognised)".format(other))
-
-
-class AngryIsh(object):
-    def __eq__(self, other):
-        if detect_and_predict_face_emotion is not None and _is_image(other):
-            return detect_and_predict_face_emotion(other) == 0
-        raise ValueError(
-            "Maybe! ({!r} is not recognised)".format(other))
-
-
-class NeutralIsh(object):
-    def __eq__(self, other):
-        if detect_and_predict_face_emotion is not None and _is_image(other):
-            return detect_and_predict_face_emotion(other) == 6
-        raise ValueError(
-            "Maybe! ({!r} is not recognised)".format(other))
+        if self._is_image(other):
+            return detect_and_predict_face_emotion(other) == self._type
+        raise Maybe(other)
 
 
 class Ish(object):
+    _module = sys.modules[__name__]
+
+    UnIshable = UnIshable
+    Maybe = Maybe
+
     def __rsub__(self, other):
         if other is True:
             return trueish
-        elif other is False:
+        if other is False:
             return falseish
-        elif isinstance(other, basestring):
-            normalized = normalize_string(other)
-            if normalized in HAPPY_STRINGS:
-                return happyish
-            elif normalized in ANGRY_STRINGS:
-                return angryish
-            elif normalized in NEUTRAL_STRINGS:
-                return neutralish
-        raise UnIshable('{0!r} cannot be ished'.format(other))
+        if isinstance(other, basestring):
+            return EmotionIsh(other)
+        raise UnIshable(other)
 
+    def __repr__(self):
+        return 'ish'
 
-happyish = HappyIsh()
-angryish = AngryIsh()
-neutralish = NeutralIsh()
-trueish = TrueIsh()
-falseish = FalseIsh()
-ish = Ish()
-__rsub__ = ish.__rsub__
-
-
-class RsubableModule(type(sys)):
-    def __init__(self, original_module):
-        type(sys).__init__(self, original_module.__name__)
-        self._original_module = original_module
-
-    def __rsub__(self, *args, **kwargs):
-        return self._original_module.__rsub__(*args, **kwargs)
-
-    def __getattribute__(self, item):
-        if item in ['__rsub__', '_original_module']:
-            return object.__getattribute__(self, item)
-        return getattr(self._original_module, item)
-
-
-sys.modules[__name__] = RsubableModule(sys.modules[__name__])
+ish = ish.ish = sys.modules[__name__] = Ish()
 
 
 if __name__ == '__main__':

--- a/ish/ish.py
+++ b/ish/ish.py
@@ -15,7 +15,7 @@ except NameError:
 
 
 TRUE_STRINGS = {
-    'true', 'yes', 'on', '1', 'yeah', 'yup', 'yarp',
+    'true', 'yes', 'on', 'yeah', 'yup', 'yarp',
     'oui',  # French
     'ja',   # German, Danish, Dutch, Afrikaans, Swedish, Norwegian
     'sim',  # Portuguese
@@ -24,7 +24,7 @@ TRUE_STRINGS = {
     u'ﻦﻌﻣ', # Arabic
 }
 FALSE_STRINGS = {
-    'false', 'no', 'off', '0', 'nope', 'nah', 'narp',
+    'false', 'no', 'off', 'nope', 'nah', 'narp',
     'non',   # French
     'nein',  # German
     'nej',   # Danish
@@ -73,6 +73,11 @@ class BaseIsh(object):
 class BoolIsh(BaseIsh):
     def _check_string(self, s):
         normalized = normalize_string(s)
+
+        try:
+            return bool(int(normalized))
+        except ValueError:
+            pass
 
         if normalized in TRUE_STRINGS:
             return True

--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -4,8 +4,7 @@ import pytest
 
 import ish
 from ish import ish as ish_  # backwards compatibility
-from ish import TRUE_STRINGS
-from ish import HappyIsh, AngryIsh, NeutralIsh, UnIshable
+from ish import UnIshable
 
 
 def test_true_ish():
@@ -30,18 +29,6 @@ def test_false_ish():
 def test_maybe():
     with pytest.raises(ValueError):
         'Whatever' == True-ish
-
-
-def test_happy_ish():
-    assert isinstance('happy'-ish, HappyIsh)
-
-
-def test_angry_ish():
-    assert isinstance('angry'-ish, AngryIsh)
-
-
-def test_neutral_ish():
-    assert isinstance('neutral'-ish, NeutralIsh)
 
 
 def test_error():

--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -28,6 +28,7 @@ def test_false_ish():
     assert 'Nope' == False-ish
     assert 'Narp' == False-ish
     assert 'Nah' == False-ish
+    assert '' == False-ish
 
 
 def test_maybe():

--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -20,6 +20,10 @@ def test_true_ish_unicode():
     assert mine == True-ish
 
 
+def test_extra_chars():
+    assert ' Yeah!!!' == True-ish
+
+
 def test_false_ish():
     assert 'Nope' == False-ish
     assert 'Narp' == False-ish


### PR DESCRIPTION
As the codebase of the `ish` module is growing as it increases in popularity and adopters, I found that the code needs a refactoring. Therefore I submitted this PR which does following improvements to the code:
- Turned `TRUE_STRINGS` and `FALSE_STRINGS` into a set (this is the correct, and also a more efficient, data structure as we don't mind the order of these strings but simply check whether a given string is in the given set).
- Replaced `u'..'.lower()` with the respective literals.
- Merged the classes `TrueIsh` and `FalseIsh` into a common class `BoolIsh` (this way the logic is more consistent)
  - That way I could also easily (and without duplication) implement the `__repr__` method for a more natural user exprience when using the REPL.
- Moved the logic to normalize and check strings for their true-ish-ness into separate methods, also removing some unnecessary complexity there, and making that logic easier to understand.
- Simplified the module magic, by simply setting `sys.modules[__name__] = ish` instead subclassing the module type, as suggested in #2.
