### PR TITLE
Make empty string False-ish

### DIFF
--- a/ish/ish.py
+++ b/ish/ish.py
@@ -10,7 +10,7 @@ TRUE_STRINGS = [
     u'نعم'.lower(),  # Arabic
 ]
 FALSE_STRINGS = [
-    'false', 'no', 'off' '0', 'nope', 'nah',
+    'false', 'no', 'off' '0', 'nope', 'nah', '',
     'non',   # French
     'nein',  # German
     'nej',   # Danish

--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -19,6 +19,7 @@ def test_true_ish_unicode():
 def test_false_ish():
     assert 'Nope' == False-ish
     assert 'Nah' == False-ish
+    assert '' == False-ish
 
 
 def test_maybe():


### PR DESCRIPTION
Empty strings should probably be considered False-ish, rather than causing `ValueError('Maybe!')`.
