### PR TITLE
Make ish support numbers

### DIFF
--- a/ish/test_ish.py
+++ b/ish/test_ish.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from decimal import Decimal
+from fractions import Fraction
 
 import ish
 from ish import ish as ish_  # backwards compatibility
@@ -29,6 +31,16 @@ def test_false_ish():
     assert 'Narp' == False-ish
     assert 'Nah' == False-ish
     assert '' == False-ish
+
+
+def test_number_ish():
+    assert 0.2 == 0-ish
+    assert 0.6 > 0-ish
+    assert '0.2' == 0-ish
+    assert 0.4 == 0.5-ish
+    assert 120 == 100-ish
+    assert Decimal('1.2') == 1-ish
+    assert Fraction('6/5') == 1-ish
 
 
 def test_maybe():


### PR DESCRIPTION
Comparing an object againts a numeric value is quite a hassle in Python. Some objects compare smoothly (e.g `0 == 0.0`), but others don't (e.g. `"0" == 0`, same when comparing an object implementing `__int__` or `__float__` to a number).

Also what should happen if you compare a float (probably being inaccurate anyway) with an integer? Doing an exact comparison of numbers just feels unnatural and is causing a lot of confusion.

I fixed this! With this PR all of the following evaluate to True:

``` python
'0' == 0-ish
0.1 == 0-ish
12 == 10-ish

from fractions import Fraction
Fraction('6/5') == 1-ish

class MyAwesomeIntishObject:
    def __int__(self):
        return 99
MyAwesomeIntishObject() == 100ish
```
