### PR TITLE
Fix one line regexp for functions

### DIFF
--- a/one_line_regex.py
+++ b/one_line_regex.py
@@ -5,14 +5,14 @@ import re
 import sys
 
 
-def magic_match(pattern, target):
+def magic_match(*args, **kwargs):
     """
     Match a regex against a target string.
 
     Assign the result to a 'match' variable in the *caller's global scope*.
     """
     frame = sys._getframe(1)
-    result = re.match(pattern, target)
+    result = re.match(*args, **kwargs)
     # This is properly, properly evil. Don't do this:
     frame.f_globals['match'] = result
     return result

--- a/one_line_regex.py
+++ b/one_line_regex.py
@@ -18,7 +18,8 @@ def magic_match(pattern, target):
     return result
 
 
-if magic_match(r'[abcde]+', sys.argv[1]):
-    print 'Your match was %r' % match.group(0)
-else:
-    print 'There was no match'
+if __name__ == '__main__':
+    if magic_match(r'[abcde]+', sys.argv[1]):
+        print 'Your match was %r' % match.group(0)
+    else:
+        print 'There was no match'

--- a/one_line_regex.py
+++ b/one_line_regex.py
@@ -9,12 +9,12 @@ def magic_match(pattern, target):
     """
     Match a regex against a target string.
 
-    Assign the result to a 'match' variable in the *caller's scope*.
+    Assign the result to a 'match' variable in the *caller's global scope*.
     """
     frame = sys._getframe(1)
     result = re.match(pattern, target)
     # This is properly, properly evil. Don't do this:
-    frame.f_locals['match'] = result
+    frame.f_globals['match'] = result
     return result
 
 


### PR DESCRIPTION
I looked into the issue you told me about the other day, that `one_line_regex.match_magic()` doesn't work when called from within a function, but only when called from the top-level scope.

That is because accessing a variable that hasn't been defined results into a `LOAD_GLOBAL` instruction. But you assign to the caller's local scope. However, if the function is called from the top-level scope `f_globals == f_locals`. That is the reason it still worked in that scenario. So the fix is as simple as assigning to the callers global scope instead, and voila `magic_match()` works within function calls as well.

Of course this bears side effects like polluting the global scope, but I'm confident this is the only way to make it work (without a decorator rewriting the byte code). Also there is still a corner case left that seems to be impossible to tackle (without rewriting the byte code):

``` python
def foo():
    match = None
    magic_match(r'.*', 'foo')
    print match
```

In that case `FAST_LOAD` is used to lookup the variable `match` and globals are ignored. However, assigning to locals wouldn't help either, because the value of the variable is looked up from the stack.

The other changes in this PR are just minor code cleanups (isolated in separate commits) to allow importing this file actually as module and passing additional parameters such as flags.
